### PR TITLE
NXBT-3426: Fix platform-staging DOCKER_REGISTRY env var

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -17,6 +17,7 @@ github-api:1.115
 github-branch-source:2.8.3
 github-oauth:0.33
 jackson2-api:2.11.2
+jira:3.1.1
 jquery3-api:3.5.1-1
 junit:1.34
 kubernetes:1.26.4
@@ -40,3 +41,4 @@ workflow-basic-steps:2.20
 workflow-cps:2.82
 workflow-cps-global-lib:2.17
 workflow-job:2.39
+workflow-support:3.5

--- a/staging/config/jenkins.yaml
+++ b/staging/config/jenkins.yaml
@@ -23,7 +23,7 @@ jenkins:
           - key: "ARENDER_DOCKER_REGISTRY"
             value: "docker-arender.packages.nuxeo.com"
           - key: "DOCKER_REGISTRY"
-            value: "docker.platform.dev.nuxeo.com"
+            value: "docker.platform-staging.dev.nuxeo.com"
           - key: "DRY_RUN"
             value: "true"
           - key: "PRIVATE_DOCKER_REGISTRY"


### PR DESCRIPTION
We need to fix the `jira` and `workflow-support` plugin versions, otherwise `install-plugins.sh` might try to pull the latest one, breaking Jenkins with plugin dependency issues.